### PR TITLE
Update ReadMe.md so Bower noobs avoid setup errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ stuff in place, I hope this will see to 90% of questions and issues.
 ## As quick as possible
 
 The quickest, simplest way to get started with inuitcss is via the [Starter
-Kit](https://github.com/inuitcss/starter-kit). Simply run
+Kit](https://github.com/inuitcss/starter-kit). 
+
+NB. If you have not previously installed Bower, first do so globally: 
+    $ [sudo] npm install -g bower
+then initialize an instance of it in your working directory:
+    $ bower init
+After that you can simply run
 
     $ bower install --save inuit-starter-kit
 


### PR DESCRIPTION
Inuit fans who lack Bower experience (hand raised!) may benefit from a little more info about getting Bower installed before they run the <code>$ bower install --save inuit-starter-kit</code> instruction. For instance, I didn't know I had to do a <code>$ bower init</code> first, and thus got various complaints. Since I'm (at least initially) only using Bower to get at the latest and greatest InuitCSS (Yay!), little tips like that would make for a better experience. Word it any way you like, but something like this would certainly have helped _me_.
